### PR TITLE
Change to incident radiation and Hyytiala parameters

### DIFF
--- a/pyAPES/microclimate/radiation.py
+++ b/pyAPES/microclimate/radiation.py
@@ -342,8 +342,10 @@ def canopy_sw_ZhaoQualls(LAIz: np.ndarray, Clump: float, x: float, Zen: float,
                          IbSky: float, IdSky:float, LeafAlbedo: float, SoilAlbedo: float
                          , PlotFigs: bool=False) -> Tuple:
     """
-    Computes short-wave (SW) radiation transfer inside horizontally homogeneous multi-layer canopy. Includes
-    multiple reflections between foliage layers and soil surface.
+    Computes short-wave (SW) radiation transfer inside horizontally homogeneous multi-layer 
+    canopy using two-stream approach. Includes multiple reflections between foliage layers and soil surface.
+    Incident radiation is given per ground area to be in line with A-gs measurements at leaf and shoot scale, i.e.
+    Vcmax and Jmax reported in literature.
 
     Reference:
         Zhao W. & Qualls R.J. (2005). A multiple-layer canopy scattering model
@@ -353,11 +355,14 @@ def canopy_sw_ZhaoQualls(LAIz: np.ndarray, Clump: float, x: float, Zen: float,
     Note: 
         To get sunlit fraction below all vegetation: f_sl[0] / Clump.
 
-        At least for conifers NIR LeafAlbedo has to be decreased from leaf-scale  values to correctly 
-        model canopy albedo of clumped canopies. Adjustment from ~0.7 to 0.55 seems to be sufficient.
-        This corresponds roughlty to a=a_needle*[4*STAR / (1- a_needle*(1-4*STAR))], where a_needle is needle albedo
-        and STAR silhouette to total area ratio of a conifer shoot. STAR ~0.09-0.21 (mean 0.14)
-        for Scots pine (Smolander, Stenberg et al. -papers)
+        Within-clump shading is accounted for by conceptualizing three leaf pools:
+          1. Truly sunlit (outer clump surface): fraction f_sl = Clump * exp(-Kb * Clump * LAI_cum) of physical LAI.
+             These leaves receive full direct beam + diffuse.
+          2. Within-clump self-shaded: fraction (1-Clump) * exp(-Kb * Clump * LAI_cum) of physical LAI.
+             These leaves are in a sunlit clump but shielded inside it; receive diffuse only.
+          3. Canopy-shaded: fraction 1 - exp(-Kb * Clump * LAI_cum) of physical LAI.
+             Receive diffuse only.
+        Pools 2 and 3 are merged into a single shaded pool with f_sh = 1 - Clump * exp(-Kb * Clump * LAI_cum).
 
     Args:
         LAIz (array): [m2 m-2 (ground)], layewise one-sided leaf-area index
@@ -375,12 +380,14 @@ def canopy_sw_ZhaoQualls(LAIz: np.ndarray, Clump: float, x: float, Zen: float,
             SWbo (array): [W m-2 (ground)], direct radiation; 
             SWdo (array): [W m-2 (ground)], downwelling diffuse radiation; 
             SWuo (array): [W m-2 (ground)], upwelling diffuse; 
-            Q_sl (array): [W m-2 (leaf)] incident SW radiation normal to sunlit leaves; 
-            Q_sh: (array): [W m-2 (leaf)] incident SW radiation normal to shaded leaves; 
-            q_sl: (array): [W m-2 (leaf)], absorbed SW by sunlit leaves; 
-            q_sh: (array): [W m-2 (leaf)], absorbed SW by shaded leaves; 
+            Q_sl (array): [W m-2 (ground)] incident SW for truly sunlit un-clumped (physical) leaf area; 
+            Q_sh: (array): [W m-2 (ground)] incident SW for shaded un-clumped (physical) leaf area; 
+            q_sl: (array): [W m-2 (leaf)], absorbed SW per unit truly sunlit un-clumped (physical) leaf area; 
+            q_sh: (array): [W m-2 (leaf)], absorbed SW per unit shaded un-clumped (physical) leaf area; 
             q_soil (float): [W m-2 (ground)], absorbed SW by ground; 
-            f_sl: (array): [-] sunlit fraction of leaves; 
+            f_sl: (array): [-] truly sunlit fraction of physical leaf area = Clump * exp(-Kb*Clump*LAI_cum);
+                           = outer clump surface fraction; within-clump self-shaded leaves are in shaded pool;
+                           multiply by LAIz for truly sunlit physical leaf area per layer;
             alb (array): [-] ecosystem SW albedo; 
     
     """
@@ -504,8 +511,7 @@ def canopy_sw_ZhaoQualls(LAIz: np.ndarray, Clump: float, x: float, Zen: float,
         X = SWd0[k+1] / (1 - rd[k]*rd[k+1]*(1-aL[k])*(1 - taud[k])*(1 - aL[k+1])*(1 - taud[k+1]))
         Y = SWu0[k]*rd[k+1]*(1 - aL[k+1])*(1 - taud[k+1]) / (1 - rd[k]*rd[k+1]*(1 - aL[k])*(1 - taud[k])*(1 - aL[k+1])*(1 - taud[k+1]))
         SWd[k+1] = X + Y
-    SWd[0] = SWd[1] # SWd0[0]
-    # print SWd
+    SWd[0] = SWd[1]
 
     # upwelling diffuse after multiple scattering, eq. 25
     SWu = np.zeros([M+1])
@@ -522,8 +528,15 @@ def canopy_sw_ZhaoQualls(LAIz: np.ndarray, Clump: float, x: float, Zen: float,
     aL = aL[0:M+1]
 
     # --- NOW return values back to the original grid
+    # Between-clump sunlit fraction of ground area (= exp(-Kb * Clump * cumsum(LAIz))).
+    # Used only to derive SWbo; NOT returned as f_sl.
     f_slo = np.exp(-Kb*(Lcumo))
-    SWbo = f_slo*IbSky  # Beam radiation
+    SWbo = f_slo*IbSky                # Beam radiation at each level [W m-2 ground]
+
+    # Truly sunlit fraction of physical leaf area = Clump * f_slo.
+    # Physical interpretation: only the outer clump surface (fraction Clump of physical LAI)
+    # is exposed to direct beam; the inner (1-Clump) fraction is always within-clump self-shaded.
+    f_slo_true = Clump * f_slo
 
     # interpolate diffuse fluxes
     X = np.flipud(Lcumo)
@@ -531,85 +544,147 @@ def canopy_sw_ZhaoQualls(LAIz: np.ndarray, Clump: float, x: float, Zen: float,
     SWdo = np.flipud(np.interp(X, xi, np.flipud(SWd)))
     SWuo = np.flipud(np.interp(X, xi, np.flipud(SWu)))
 
-    # incident radiation on sunlit and shaded leaves Wm-2
-    # Q_sh = Clump*Kd*(SWdo + SWuo)  # normal to shaded leaves is all diffuse
-    # Q_sl = Kb*IbSky + Q_sh  # normal to sunlit leaves is direct and diffuse
-    # SUGGESTED CHANGE: clumped leaves are shaded so "divide" diffuse radiation only for shaded leaves based on clumping (incident PAR of sunlit increases)
-    Q_sh = Clump*(1-f_slo)/(1-Clump*f_slo) * Kd*(SWdo + SWuo)
-    Q_sl = Kb*IbSky + Kd*(SWdo + SWuo)
-
-    # absorbed components
-    aLo = np.ones(len(Lo))*(1 - LeafAlbedo)
-    aDiffo = aLo*Kd*(SWdo + SWuo)
-    aDiro = aLo*Kb*IbSky
-
     # stand albedo
     alb = SWuo[-1] / (IbSky + IdSky + EPS)
-    # print alb
     # soil absorption (Wm-2 (ground))
     q_soil = (1 - SoilAlbedo)*(SWdo[0] + SWbo[0])
 
-    # correction to match absorption-based and flux-based albedo, relative error <3% may occur
-    # in daytime conditions, at nighttime relative error can be larger but fluxes are near zero
-    aa = (sum(aDiffo*Lo + aDiro*f_slo*Lo) + q_soil) / (IbSky + IdSky + EPS)
-    F = (1. - alb) / aa
-    # print('F', F)
-    if F <= 0 or np.isfinite(F) is False:
-        F = 1.
+    #--- absorbed components per layer (per unit un-clumped / physical leaf area) ---
+    # Exact flux-divergence formulation.
+    # Arrays SWbo/SWdo/SWuo[k] are at the BOTTOM of layer k (index 0 = canopy bottom).
+    # Top-of-layer k = bottom-of-layer k+1, except for the topmost layer where
+    # canopy-top upwelling is approximated as SWuo[-1] (exact for all other layers).
+    aLo = np.ones(len(Lo))*(1 - LeafAlbedo)
 
-    aDiro = F*aDiro
-    aDiffo = F*aDiffo
-    q_soil = F*q_soil
+    SWdo_top = np.append(SWdo[1:], IdSky)
+    SWuo_top = np.append(SWuo[1:], SWuo[-1])  # approx for top layer only
+    SWbo_top = np.append(SWbo[1:], IbSky)
 
-    # sunlit fraction in clumped foliage; clumping means elements shade each other
-    f_slo = Clump*f_slo
+    # Total absorbed per layer [W m-2 ground] = divergence of net downward flux
+    total_abs = (SWbo_top + SWdo_top - SWuo_top) - (SWbo + SWdo - SWuo)
 
-    # Following adjustment is required for energy conservation, i.e. total absorbed radiation
-    # in a layer must equal difference between total radiation(SWup, SWdn) entering and leaving the layer.
-    # Note that this requirement is not always fullfilled in canopy rad. models.
-    # now sum(q_sl*f_slo* + q_sh*(1-f_slo)*Lo = (1-alb)*(IbSky + IdSky)
-    q_sh = aDiffo*Clump  # shaded leaves only diffuse
-    q_sl = q_sh + aDiro  # sunlit leaves diffuse + direct
+    # Beam absorbed per layer [W m-2 ground]
+    abs_beam = aLo * (SWbo_top - SWbo)
 
-    # SAME CHANGE HERE TOO: note f_slo now unclumped
-    q_sh = Clump*(1-f_slo/Clump)/(1-f_slo) * aDiffo
-    q_sl = aDiffo + aDiro  # sunlit leaves diffuse + direct
+    # Absorbed per unit physical leaf area [W m-2 physical leaf].
+    # Dividing abs_beam by (f_slo_true * LAIz) = (Clump * f_slo * LAIz) gives the full
+    # direct beam per truly sunlit leaf: aDiro ≈ aL * Kb * IbSky  (sun-angle-projected beam).
+    # The (1-Clump)*f_slo within-clump self-shaded leaves and the (1-f_slo) canopy-shaded
+    # leaves are all merged into the shaded pool and receive only diffuse (aDiffo).
+    aDiffo = (total_abs - abs_beam) / np.maximum(LAIz, EPS)        # diffuse; per unit LAIz
+    aDiro  = abs_beam / np.maximum(f_slo_true * LAIz, EPS)         # beam; per unit truly sunlit LAIz
 
+    # --- Sunlit / shaded split, energy-conserving ---
+    # f_slo_true = Clump * exp(-Kb * Clump * LAI_cum) is the truly sunlit fraction.
+    # Shaded pool = within-clump self-shaded [(1-Clump)*f_slo] + canopy-shaded [1-f_slo].
+    #
+    # Conservation check:
+    #   q_sl * f_slo_true * LAIz + q_sh * (1 - f_slo_true) * LAIz
+    #   = (aDiffo + aDiro) * f_slo_true * LAIz + aDiffo * (1 - f_slo_true) * LAIz
+    #   = aDiffo * LAIz + aDiro * f_slo_true * LAIz
+    #   = (total_abs - abs_beam) + abs_beam = total_abs  [exact]
+    q_sh = aDiffo  # [W m-2 physical leaf], shaded (incl. within-clump self-shaded)
+    q_sl = aDiffo + aDiro  # [W m-2 physical leaf], truly sunlit
+
+    # Incident radiation is given per ground area. 
+    # Sunlit leaves receive direct (IbSky) + diffuse (SWdo + SWuo), shaded leaves receive diffuse only (SWdo + SWuo).
+    Q_sl = IbSky + SWdo + SWuo  # [W m-2 ground], incident on truly sunlit un-clumped (physical) leaf area
+    Q_sh = SWdo + SWuo  # [W m-2 ground], incident on shaded un-clumped (physical) leaf area
+
+    # old approach
+    # Q_sh = Clump*Kd*(SWdo + SWuo)  # normal to shaded leaves is all diffuse
+    # Q_sl = Kb*IbSky + Q_sh  # normal to sunlit leaves is direct and diffuse
+
+    # --- for diagonstics ---
     if PlotFigs:
-        fig, ax = plt.subplots(2,2, figsize=(6,8))
+        depth = -Lcumo / Clump   # y-axis: 0 near top, -LAI/Clump at bottom
 
-        # add input parameter values to fig
-        ax[0,0].text(0.05, 0.65, r'$LAI$ = %1.1f m2 m-2' % (LAI))
-        ax[0,0].text(0.50, 0.65, r'$ZEN$ = %1.3f ' % (Zen / DEG_TO_RAD))
-        ax[0,0].text(0.70, 0.65, r'$\alpha_l$ = %0.2f' % (LeafAlbedo))
-        ax[0,0].text(1.0, 0.65, r'$\alpha_s$ = %0.2f' % (SoilAlbedo))
+        # --- conservation quantities ---
+        SWbo_int = np.append(SWbo, IbSky)
+        SWdo_int = np.append(SWdo, IdSky)
+        SWuo_int = np.append(SWuo, alb * (IbSky + IdSky))
+        net_down  = SWbo_int + SWdo_int - SWuo_int
+        abs_flux  = np.diff(net_down)
+        abs_leaf  = q_sl * f_slo_true * LAIz + q_sh * (1 - f_slo_true) * LAIz
 
-        ax[0,0].set_title("Source: radiation.canopy_sw_ZhaoQualls")
+        fig, axes = plt.subplots(2, 3, figsize=(15, 9))
+        fig.suptitle(
+            f"canopy_sw_ZhaoQualls_unclumped  LAI={sum(LAIz):.1f} m2 m-2,  Zen={Zen/DEG_TO_RAD:.0f} deg,"
+            f"  Clump={Clump},  aL={LeafAlbedo},  as={SoilAlbedo}",
+            fontsize=11)
 
-        ax[0,0].plot(f_slo, -Lcumo/Clump, 'r-', (1 - f_slo), -Lcumo/Clump, 'b-')
-        ax[0,0].set_ylabel("-Lcum eff.")
-        ax[0,0].set_xlabel("sunlit & shaded fractions (-)")
-        ax[0,0].legend(('f$_{sl}$, total = %.2f' % np.sum(f_slo*LAIz), 'f$_{sh}$, total = %.2f' % np.sum((1 - f_slo)*LAIz)), loc='best')
+        # SW flux profiles
+        ax = axes[0, 0]
+        ax.plot(SWbo, depth, 'r-o', ms=4, label='Direct beam SWbo')
+        ax.plot(SWdo, depth, 'b-o', ms=4, label='Diffuse down SWdo')
+        ax.plot(SWuo, depth, 'g-o', ms=4, label='Diffuse up SWuo')
+        ax.set_xlabel('Flux [W m-2 ground]')
+        ax.set_ylabel('-Lcum / Clump')
+        ax.set_title('SW flux profiles')
+        ax.legend(fontsize=8)
+        ax.grid(alpha=0.3)
 
-        ax[0,1].plot(Q_sl, -Lcumo/Clump, 'ro-', Q_sh, -Lcumo/Clump, 'bo-')
-        ax[0,1].plot(q_sl/(1-LeafAlbedo), -Lcumo/Clump, 'k-', q_sh/(1-LeafAlbedo), -Lcumo/Clump, 'k-')
-        ax[0,1].set_ylabel("-Lcum eff.")
-        ax[0,1].set_xlabel("Incident radiation (Wm-2 (leaf))")
-        ax[0,1].legend(('sunlit', 'shaded'), loc='best')
+        # Three-pool fractions
+        ax = axes[0, 1]
+        ax.plot(f_slo_true, depth, 'r-o', ms=4,
+                label=r'f$_{sl}$ truly sunlit = $\Omega \cdot e^{-K_b \Omega L}$')
+        ax.plot((1 - Clump) * f_slo, depth, 'm--o', ms=4,
+                label=r'within-clump self-shaded = $(1-\Omega) \cdot e^{-K_b \Omega L}$')
+        ax.plot(1 - f_slo, depth, 'b-o', ms=4,
+                label=r'canopy-shaded = $1 - e^{-K_b \Omega L}$')
+        ax.plot(1 - f_slo_true, depth, 'k--o', ms=4,
+                label=r'total shaded = $1 - \Omega \cdot e^{-K_b \Omega L}$')
+        ax.set_xlabel('Fraction [-]')
+        ax.set_ylabel('-Lcum / Clump')
+        ax.set_title('Three-pool leaf fractions')
+        ax.legend(fontsize=7)
+        ax.grid(alpha=0.3)
+        ax.set_xlim(0, 1)
 
-        ax[1,0].plot(SWd, -Lcum/Clump, 'bo', SWdo, -Lcumo/Clump, 'b-', Ib, -Lcum/Clump, 'ro',
-                 SWbo, -Lcumo/Clump, 'r-', SWu, -Lcum/Clump, 'go', SWuo, -Lcumo/Clump, 'g-')
-        ax[1,0].legend(('SWd', 'Swdo', 'SWb', 'SWbo', 'SWu', 'SWuo'), loc='best')
-        ax[1,0].set_ylabel("-Lcum eff.")
-        ax[1,0].set_xlabel("Incident SW (Wm-2 )")
+        # Incident per physical leaf area
+        ax = axes[0, 2]
+        ax.plot(Q_sl, depth, 'r-o', ms=4, label='Q_sl truly sunlit')
+        ax.plot(Q_sh, depth, 'b-o', ms=4, label='Q_sh shaded')
+        ax.set_xlabel('Incident [W m-2 physical leaf]')
+        ax.set_ylabel('-Lcum / Clump')
+        ax.set_title('Incident radiation per physical leaf area')
+        ax.legend(fontsize=8)
+        ax.grid(alpha=0.3)
 
-        ax[1,1].plot(q_sl, -Lcumo/Clump, 'ro-', q_sh, -Lcumo/Clump, 'bo-')
-        ax[1,1].plot((1-np.exp(-Kd*Lo))*(SWdo + SWuo)/(LAIz+EPS),-Lcumo/Clump,'-k')
-        ax[1,1].set_ylabel("-Lcum eff.")
-        ax[1,1].set_xlabel("Absorbed radiation (Wm-2 (leaf))")
-        ax[1,1].legend(('sunlit', 'shaded'), loc='best')
+        # Absorbed per physical leaf area
+        ax = axes[1, 0]
+        ax.plot(q_sl, depth, 'r-o', ms=4, label='q_sl truly sunlit')
+        ax.plot(q_sh, depth, 'b-o', ms=4, label='q_sh shaded')
+        ax.set_xlabel('Absorbed [W m-2 physical leaf]')
+        ax.set_ylabel('-Lcum / Clump')
+        ax.set_title('Absorbed radiation per physical leaf area')
+        ax.legend(fontsize=8)
+        ax.grid(alpha=0.3)
 
-    return SWbo, SWdo, SWuo, Q_sl, Q_sh, q_sl, q_sh, q_soil, f_slo, alb
+        # Per-layer conservation comparison
+        ax = axes[1, 1]
+        ax.plot(abs_leaf, depth, 'k-o', ms=4,
+                label=r'Leaf-based: $q_{sl} f_{sl} LAI_z + q_{sh}(1-f_{sl})LAI_z$')
+        ax.plot(abs_flux, depth, 'r--s', ms=4, label='Flux divergence (net_down diff)')
+        ax.set_xlabel('Layer absorbed [W m-2 ground]')
+        ax.set_ylabel('-Lcum / Clump')
+        ax.set_title('Per-layer absorption: leaf vs flux')
+        ax.legend(fontsize=7)
+        ax.grid(alpha=0.3)
+
+        # Residual
+        ax = axes[1, 2]
+        ax.plot(abs_leaf - abs_flux, depth, 'k-o', ms=4)
+        ax.axvline(0, color='r', linestyle='--', linewidth=1)
+        ax.set_xlabel('Residual: leaf - flux divergence [W m-2 ground]')
+        ax.set_ylabel('-Lcum / Clump')
+        ax.set_title('Layer conservation residual\n(non-zero only for top layer: SWuo_top approx.)')
+        ax.grid(alpha=0.3)
+
+        plt.tight_layout()
+        plt.show()
+
+    return SWbo, SWdo, SWuo, Q_sl, Q_sh, q_sl, q_sh, q_soil, f_slo_true, alb
 
 def canopy_sw_Spitters(LAIz: np.ndarray, Clump: float, x: float, Zen: float,
                        IbSky: float, IdSky: float, LeafAlbedo: float, SoilAlbedo: float,

--- a/pyAPES/parameters/SmearII_parameters.py
+++ b/pyAPES/parameters/SmearII_parameters.py
@@ -99,19 +99,19 @@ pt1 = { 'name': 'pine',
             },
         # A-gs model: pyAPES.leaf.photo
         'photop': {
-            'Vcmax': 80, # 50.0, # maximum carboxylation rate [umol m-2 (leaf) s-1] at 25 degC
-            'Jmax': 160, # 98.0,  # maximum electron transport rate[umol m-2 (leaf) s-1] at 25 degC1.97*Vcmax (Kattge and Knorr, 2007)
-            'Rd': 0.9, # 1.2, # dark respiration rate [umol m-2 (leaf) s-1] at 25 degC
+            'Vcmax': 50.0, # maximum carboxylation rate [umol m-2 (leaf) s-1] at 25 degC
+            'Jmax': 98.0,  # maximum electron transport rate[umol m-2 (leaf) s-1] at 25 degC1.97*Vcmax (Kattge and Knorr, 2007)
+            'Rd': 1.2, # dark respiration rate [umol m-2 (leaf) s-1] at 25 degC
             'tresp': { # temperature response (Kattge and Knorr, 2007)
                 'Vcmax': [53., 200.0, 640.], # [activation energy [kJ mol-1], deactivation energy [kJ mol-1]
                                  #             entropy factor [kJ mol-1]]
                 'Jmax': [38., 200.0, 656.],
-                'Rd': [36.0], ##[33.0]
+                'Rd': [33.0]
                 },
             'alpha': 0.1,   # quantum efficiency parameter [-]
             'theta': 0.7,   # curvature parameter [-]
             'beta': 0.95,   # co-limitation parameter [-]
-            'g1': 2.0, # 2.8,      # USO-model stomatal slope kPa^(0.5)
+            'g1': 2.0, #2.8,      # USO-model stomatal slope kPa^(0.5)
             'g0': 1.0e-3,   # residual conductance for CO2 [mol m-2 s-1]
             'kn': 0.5,      # nitrogen attenuation coefficient; affects Vcmax, Jmax, Rd profile in PlantType [-]
             'drp': [0.39, 0.83, 0.31, 3.0] # Rew-based drought response parameters.
@@ -154,19 +154,19 @@ pt2 = { 'name': 'spruce',
             },
         # A-gs model: pyAPES.leaf.photo
         'photop': {
-            'Vcmax': 50.0, # maximum carboxylation rate [umol m-2 (leaf) s-1] at 25 degC
-            'Jmax': 98.0,  # maximum electron transport rate[umol m-2 (leaf) s-1] at 25 degC1.97*Vcmax (Kattge and Knorr, 2007)
-            'Rd': 1.2, # dark respiration rate [umol m-2 (leaf) s-1] at 25 degC
+            'Vcmax': 45.0, #50.0, # maximum carboxylation rate [umol m-2 (leaf) s-1] at 25 degC
+            'Jmax': 89.0, #98.0,  # maximum electron transport rate[umol m-2 (leaf) s-1] at 25 degC1.97*Vcmax (Kattge and Knorr, 2007)
+            'Rd': 1.1, #1.2, # dark respiration rate [umol m-2 (leaf) s-1] at 25 degC
             'tresp': { # temperature response (Kattge and Knorr, 2007)
                 'Vcmax': [53., 200.0, 640.], # [activation energy [kJ mol-1], deactivation energy [kJ mol-1]
                                  #             entropy factor [kJ mol-1]]
                 'Jmax': [38., 200.0, 656.],
                 'Rd': [33.0]
                 },
-            'alpha': 0.2,   # quantum efficiency parameter [-]
+            'alpha': 0.1,   # quantum efficiency parameter [-]
             'theta': 0.7,   # curvature parameter [-]
             'beta': 0.95,   # co-limitation parameter [-]
-            'g1': 2.8,      # USO-model stomatal slope kPa^(0.5)
+            'g1': 3.0, #2.8,      # USO-model stomatal slope kPa^(0.5)
             'g0': 1.0e-3,   # residual conductance for CO2 [mol m-2 s-1]
             'kn': 0.5,      # nitrogen attenuation coefficient; affects Vcmax, Jmax, Rd profile in PlantType [-]
             'drp': [0.39, 0.83, 0.31, 3.0] # Rew-based drought response parameters.
@@ -218,7 +218,7 @@ pt3 = { 'name': 'decid',
                 'Jmax': [38., 200.0, 656.],
                 'Rd': [33.0]
                 },
-            'alpha': 0.2,   # quantum efficiency parameter [-]
+            'alpha': 0.1,   # quantum efficiency parameter [-]
             'theta': 0.7,   # curvature parameter [-]
             'beta': 0.95,   # co-limitation parameter [-]
             'g1': 5.2,      # USO-model stomatal slope kPa^(0.5)
@@ -273,7 +273,7 @@ pt4 = { 'name': 'shrubs',
                 'Jmax': [38., 200.0, 656.],
                 'Rd': [33.0]
                 },
-            'alpha': 0.2,   # quantum efficiency parameter [-]
+            'alpha': 0.1,   # quantum efficiency parameter [-]
             'theta': 0.7,   # curvature parameter [-]
             'beta': 0.95,   # co-limitation parameter [-]
             'g1': 5.2,      # USO-model stomatal slope kPa^(0.5)
@@ -315,7 +315,8 @@ snowpack = {
 soil_respiration = {
         'r10': 2.5, # base rate (bulk heterotrophic + autotrophic) [umol m-2 (ground) s-1]
         'q10': 2.0, # temperature sensitivity [-]
-        'moisture_coeff': [3.83, 4.43, 1.25, 0.854]  # moisture response; Skopp moisture function param [a ,b, d, g]}
+        'moisture_coeff': [3.83, 4.43, 1.25, 0.854],  # moisture response; Skopp moisture function param [a ,b, d, g]}
+        'beta': 0.943, # root distribution shape parameter [-]
         }
 
 # --- pyAPES.bottomlayer.OrganicLayer
@@ -469,29 +470,31 @@ cpara = {'loc': loc,
 
 # grid and soil properties: pF and conductivity values from Launiainen et al. (2015), Hyytiala
 
-# single soil layer
 soil_grid = {#thickness of computational layers [m]
-            'dz': [0.10],
+            'dz': [0.01, 0.01, 0.01, 0.01, 0.01, 0.01, 0.01, 0.01, 0.01, 0.01,
+                   0.02, 0.02, 0.02, 0.02, 0.02, 0.02, 0.02, 0.02, 0.02, 0.02,
+                   0.05, 0.05, 0.05, 0.05, 0.05, 0.05, 0.05, 0.05, 0.05, 0.05, 0.05, 0.05, 0.05, 0.05,
+                   0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1],
             # bottom depth of layers with different characteristics [m]
-            'zh': [-0.10]
+            'zh': [-0.05, -0.11, -0.35, -10.0]
             }
 
 soil_properties = {'pF': {  # vanGenuchten water retention parameters
-                        'ThetaS': [0.50],
-                        'ThetaR': [0.08],
-                        'alpha': [0.06],
-                        'n': [1.35]
+                        'ThetaS': [0.80, 0.50, 0.50, 0.41],
+                        'ThetaR': [0.01, 0.08, 0.08, 0.03],
+                        'alpha': [0.70, 0.06, 0.06, 0.05],
+                        'n': [1.25, 1.35, 1.35, 1.21]
                         },
-                  'saturated_conductivity_vertical': [2.1E-06],  # saturated vertical hydraulic conductivity [m s-1]
-                  'saturated_conductivity_horizontal': [2.1E-06],  # saturated horizontal hydraulic conductivity [m s-1]
+                  'saturated_conductivity_vertical': [2.42E-05, 2.08e-06, 3.06e-06, 4.17e-06],  # saturated vertical hydraulic conductivity [m s-1]
+                  'saturated_conductivity_horizontal': [2.42E-05, 2.08e-06, 3.06e-06, 4.17e-06],  # saturated horizontal hydraulic conductivity [m s-1]
                   'solid_heat_capacity': None,  # [J m-3 (solid) K-1] - if None, estimated from organic/mineral composition
                   'solid_composition': {
-                          'organic': [0.1611],
-                          'sand': [0.4743],
-                          'silt': [0.3429],
-                          'clay': [0.0217]
-                          },
-                  'freezing_curve': [0.2],  # freezing curve parameter
+                         'organic': [0.1611, 0.0714, 0.1091, 0.028],
+                         'sand': [0.4743, 0.525, 0.5037, 0.5495],
+                         'silt': [0.3429, 0.3796, 0.3641, 0.3973],
+                         'clay': [0.0217, 0.0241, 0.0231, 0.0252]
+                         },
+                  'freezing_curve': [0.2, 0.5, 0.5, 0.5],  # freezing curve parameter
                   'bedrock': {
                               'solid_heat_capacity': 2.16e6,  # [J m-3 (solid) K-1]
                               'thermal_conductivity': 3.0  # thermal conductivity of non-porous bedrock [W m-1 K-1]
@@ -500,7 +503,7 @@ soil_properties = {'pF': {  # vanGenuchten water retention parameters
 
 # --- water model: pyAPES.soil.water.Water
 
-water_model = {'solve': False,
+water_model = {'solve': True,
                'type': 'Richards',  # solution approach 'Richards' | 'Equilibrium'
                'pond_storage_max': 0.05,  #  maximum pond depth [m]
                'initial_condition': {
@@ -524,7 +527,7 @@ water_model = {'solve': False,
                 }
 
 # --- heat model: pyAPES.soil.heat.Heat
-heat_model = {'solve': False,
+heat_model = {'solve': True,
               'initial_condition': {
                       'temperature': 4.0,  # initial soil temperature [degC], assumed constant with dept - can also be array of correct length.
                       },

--- a/pyAPES/parameters/mlm_outputs.py
+++ b/pyAPES/parameters/mlm_outputs.py
@@ -48,17 +48,18 @@ output_variables = {'variables': [# variable name, description [units], (dimensi
       ['canopy_Rnet', 'net radiation balance at canopy top [W m-2]', ('date', 'simulation')],
    
       # leaf scale, per m-2 leaf
-      ['canopy_leaf_net_LW', 'net leaf longwave radiation [W m-2]', ('date', 'simulation', 'canopy')],
-      ['canopy_leaf_net_SW', 'net leaf shortwave radiation [W m-2]', ('date', 'simulation', 'canopy')],
-      ['canopy_par_absorbed_sunlit', 'absorbed PAR of sunlit leaves [W m-2]', ('date', 'simulation', 'canopy')],
-      ['canopy_par_absorbed_shaded', 'absorbed PAR of shaded leaves [W m-2]', ('date', 'simulation', 'canopy')],
+      ['canopy_leaf_net_LW', 'net leaf longwave radiation [W m-2 (leaf)]', ('date', 'simulation', 'canopy')],
+      ['canopy_leaf_net_SW', 'net leaf shortwave radiation [W m-2 (leaf)]', ('date', 'simulation', 'canopy')],
+      ['canopy_par_absorbed_sunlit', 'absorbed PAR of sunlit leaves [W m-2 (leaf)]', ('date', 'simulation', 'canopy')],
+      ['canopy_par_absorbed_shaded', 'absorbed PAR of shaded leaves [W m-2 (leaf)]', ('date', 'simulation', 'canopy')],
+      ['canopy_nir_absorbed_sunlit', 'absorbed NIR of sunlit leaves [W m-2 (leaf)]', ('date', 'simulation', 'canopy')],
+      ['canopy_nir_absorbed_shaded', 'absorbed NIR of shaded leaves [W m-2 (leaf)]', ('date', 'simulation', 'canopy')],
+
+      # incident radition is given per m-2 ground
       ['canopy_par_incident_sunlit', 'incident PAR of sunlit leaves [W m-2]', ('date','simulation','canopy')],
       ['canopy_par_incident_shaded', 'incident PAR of shaded leaves [W m-2]', ('date','simulation','canopy')],
-      ['canopy_nir_absorbed_sunlit', 'absorbed NIR of sunlit leaves [W m-2]', ('date', 'simulation', 'canopy')],
-      ['canopy_nir_absorbed_shaded', 'absorbed NIR of shaded leaves [W m-2]', ('date', 'simulation', 'canopy')],
       ['canopy_nir_incident_sunlit', 'incident NIR of sunlit leaves [W m-2]', ('date','simulation','canopy')],
       ['canopy_nir_incident_shaded', 'incident NIR of shaded leaves [W m-2]', ('date','simulation','canopy')],
-
       ['canopy_leaf_incident_par', 'leaf incident par [W m-2]', ('date', 'simulation', 'canopy')],
 
       # vertical profiles, per m-2 ground


### PR DESCRIPTION
Changes in shortwave radiation model
- Commenting improved
- Computation of absorbed fluxes now makes sure energy is conserved (minor change to earlier)
- Incident radiation defined as radiation hitting horizontal surface (Kd, Kb = 1) instead of spherical ((Kd, Kb vary with zenith angle), spherical still used in other parts of radiation model
	- Q_sh = Clump*Kd*(SWdo + SWuo) is now Q_sh = (SWdo + SWuo)
	- Q_sl = Kb*IbSky + Q_sh is now Q_sl = IbSky + Q_sh
	- This changes diurnal incident par from almost stepwise to something that resembles more incoming radiation
	- This approach enables more straight forward parametrization of photosynthesis model (requires lower Vcmax and/or alpha)
	
Changes to Hyytiälä parameter file
- Soil switched on
- Parameters adjusted (from Launiainen et al. 2022) after radiation change to fit to ecosystem and cuvette data 
	- lowering alpha (0.2->0.1)
	- decreasing spruce Vcmax (50->45) (also Jmax, Rd)
	- increasing spruce g1 (2.8->3.0) and lowering pine g1 (2.8->2.0)
- Rew is read from forcing file, should change?
- Ran for 2018, but maybe choose year with Rnet? 
- Sensible heat flux overestimated (2018), does Samuli recall something about this?